### PR TITLE
Modify smimeagen to add piped cert functionality

### DIFF
--- a/src/cnt_smime_association.cc
+++ b/src/cnt_smime_association.cc
@@ -120,67 +120,6 @@ bool CntSmimeAssociation::initFromPipe(CntUsage_e p_eUsage,
   return isInitialized();
 }
 
-bool CntSmimeAssociation::isFullCert()
-{
-  return (SEL_FULL == m_eSelector && MAT_FULL == m_eMatching);
-}
-
-bool CntSmimeAssociation::isFingerprintCert()
-{
-  return MAT_FULL != m_eMatching;
-}
-
-bool CntSmimeAssociation::isTA()
-{
-  return USG_PKIX_TA == m_eUsage || USG_DANE_TA == m_eUsage;
-}
-
-bool CntSmimeAssociation::isPKIX()
-{
-  return USG_PKIX_TA == m_eUsage || USG_PKIX_EE == m_eUsage;
-}
-
-bool CntSmimeAssociation::isEE()
-{
-  return USG_PKIX_EE== m_eUsage || USG_DANE_EE == m_eUsage;
-}
-
-CntUsage_e CntSmimeAssociation::getUsage()
-{
-  return m_eUsage;
-}
-
-CntSelector_e CntSmimeAssociation::getSelector()
-{
-  return m_eSelector;
-}
-
-CntMatching_e CntSmimeAssociation::getMatching()
-{
-  return m_eMatching;
-}
-
-bool CntSmimeAssociation::getHash(CntBytesVector_t &p_oOutput)
-{
-  bool bRet = false;
-
-  if (!isInitialized())
-  {
-    cnt_log("Association is not initialized.\n");
-  }
-  else if (MAT_FULL != m_eMatching)
-  {
-    bRet = m_oCert.calcCertAssocData(m_eSelector, m_eMatching, p_oOutput);
-  }
-  else
-  {
-    p_oOutput = m_oHash;
-    bRet = true;
-  }
-
-  return true;;
-}
-
 bool CntSmimeAssociation::initFromFile(CntUsage_e p_eUsage,
                                        CntSelector_e p_eSelector,
                                        CntMatching_e p_eMatching,

--- a/src/cnt_smime_association.cc
+++ b/src/cnt_smime_association.cc
@@ -99,6 +99,88 @@ bool CntSmimeAssociation::init(CntUsage_e p_eUsage,
   return isInitialized();
 }
 
+bool CntSmimeAssociation::initFromPipe(CntUsage_e p_eUsage,
+                                       CntSelector_e p_eSelector,
+                                       CntMatching_e p_eMatching)
+{
+  if (isInitialized())
+  {
+    clear();
+  }
+
+  m_eUsage = p_eUsage;
+  m_eSelector = p_eSelector;
+  m_eMatching = p_eMatching;
+
+  if (m_oCert.initFromPipe())
+  {
+    CntAssociation::init();
+  }
+
+  return isInitialized();
+}
+
+bool CntSmimeAssociation::isFullCert()
+{
+  return (SEL_FULL == m_eSelector && MAT_FULL == m_eMatching);
+}
+
+bool CntSmimeAssociation::isFingerprintCert()
+{
+  return MAT_FULL != m_eMatching;
+}
+
+bool CntSmimeAssociation::isTA()
+{
+  return USG_PKIX_TA == m_eUsage || USG_DANE_TA == m_eUsage;
+}
+
+bool CntSmimeAssociation::isPKIX()
+{
+  return USG_PKIX_TA == m_eUsage || USG_PKIX_EE == m_eUsage;
+}
+
+bool CntSmimeAssociation::isEE()
+{
+  return USG_PKIX_EE== m_eUsage || USG_DANE_EE == m_eUsage;
+}
+
+CntUsage_e CntSmimeAssociation::getUsage()
+{
+  return m_eUsage;
+}
+
+CntSelector_e CntSmimeAssociation::getSelector()
+{
+  return m_eSelector;
+}
+
+CntMatching_e CntSmimeAssociation::getMatching()
+{
+  return m_eMatching;
+}
+
+bool CntSmimeAssociation::getHash(CntBytesVector_t &p_oOutput)
+{
+  bool bRet = false;
+
+  if (!isInitialized())
+  {
+    cnt_log("Association is not initialized.\n");
+  }
+  else if (MAT_FULL != m_eMatching)
+  {
+    bRet = m_oCert.calcCertAssocData(m_eSelector, m_eMatching, p_oOutput);
+  }
+  else
+  {
+    p_oOutput = m_oHash;
+    bRet = true;
+  }
+
+  return true;;
+}
+
 bool CntSmimeAssociation::initFromFile(CntUsage_e p_eUsage,
                                        CntSelector_e p_eSelector,
                                        CntMatching_e p_eMatching,

--- a/src/cnt_smime_association.h
+++ b/src/cnt_smime_association.h
@@ -60,6 +60,9 @@ class CntSmimeAssociation : public CntAssociation
               uint8_t *p_pCertAssocData,
               size_t p_uDataLen,
               CntX509Encoding_e p_eEncoding = CNT_X509_DER);
+    bool initFromPipe(CntUsage_e p_eUsage,
+                      CntSelector_e p_eSelector,
+                      CntMatching_e p_eMatching);
     bool initFromFile(CntUsage_e p_eUsage,
                       CntSelector_e p_eSelector,
                       CntMatching_e p_eMatching,

--- a/src/cnt_smime_cert.cc
+++ b/src/cnt_smime_cert.cc
@@ -29,6 +29,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <iostream>
 
 #include <cstring>
 

--- a/src/cnt_smime_cert.cc
+++ b/src/cnt_smime_cert.cc
@@ -121,6 +121,16 @@ bool CntSmimeCert::init(CntBytesVector_t &p_oBytes, CntX509Encoding_e p_eEncodin
   return m_bInit;
 }
 
+bool CntSmimeCert::initFromPipe()
+{
+  // read whole PEM cert into memory piped from stdin (it's not _that_ big, right?)
+  std::string s(std::istreambuf_iterator<char>(std::cin), {});
+  // convert to byte vector to pass to init.
+  CntBytesVector_t oBytes(s.begin(),s.end());
+
+  return init(oBytes);
+}
+
 bool CntSmimeCert::initFromFile(std::string &p_sFile)
 {
   ifstream oIF(p_sFile.c_str(), std::ios::binary);

--- a/src/cnt_smime_cert.h
+++ b/src/cnt_smime_cert.h
@@ -50,6 +50,7 @@ class CntSmimeCert
     virtual ~CntSmimeCert();
 
     bool init(CntBytesVector_t &p_oBytes, CntX509Encoding_e p_eEncoding = CNT_X509_PEM);
+    bool initFromPipe();
     bool initFromFile(std::string &p_sFile);
     bool init(uint8_t *p_pBytes, size_t p_uBytesLen, CntX509Encoding_e p_eEncoding = CNT_X509_PEM);
     /*

--- a/src/smimeagen.cc
+++ b/src/smimeagen.cc
@@ -38,7 +38,7 @@ using namespace std;
 
 void _usage()
 {
-    fprintf(stdout, "smimea-gen [ <email address> <usage number> <selector number> <matching number> <cert file in PEM format> ] | -h\n");
+    fprintf(stdout, "smimea-gen [ <email address> <usage number> <selector number> <matching number> [cert file in PEM format] ] | -h\n");
 }
 
 bool _menu(string &p_sEmail, int &p_iUsage, int &p_iSel, int &p_iMat, string &p_sAccess, string &p_sFile)
@@ -186,6 +186,10 @@ int main(int argc, char *argv[])
   else
   {
     bool bOK = false;
+    bool pipeMode = false;
+    if (5 == argc) {
+      pipeMode = true;
+    }
     if (1 == argc)
     {
       bOK = _menu(sEmail, iUsage, iSelector, iMatching, sAccess, sCertFile);
@@ -211,7 +215,7 @@ int main(int argc, char *argv[])
       }
       else
       {
-        {
+        if (!pipeMode) {
           sCertFile = argv[5];
         }
 
@@ -228,6 +232,14 @@ int main(int argc, char *argv[])
       if (!oID.init(sEmail))
       {
         fprintf(stderr, "Unable to init ID.\n");
+      } else if (pipeMode) 
+      {
+        if (!oAssoc.initFromPipe((CntUsage_e) iUsage,
+                                    (CntSelector_e) iSelector,
+                                    (CntMatching_e) iMatching))
+        {
+          fprintf(stderr, "Unable to init association from pipe.\n");
+        }
       }
       else if (!oAssoc.initFromFile((CntUsage_e) iUsage,
                                     (CntSelector_e) iSelector,

--- a/src/smimeagen.cc
+++ b/src/smimeagen.cc
@@ -229,30 +229,34 @@ int main(int argc, char *argv[])
       CntSmimeAssociation oAssoc;
       string sTxt;
 
+      bool failed = false;
+
       if (!oID.init(sEmail))
       {
+        failed = true;
         fprintf(stderr, "Unable to init ID.\n");
-      } else if (pipeMode) 
-      {
-        if (!oAssoc.initFromPipe((CntUsage_e) iUsage,
+      } 
+      if (!failed && pipeMode && !oAssoc.initFromPipe((CntUsage_e) iUsage,
                                     (CntSelector_e) iSelector,
                                     (CntMatching_e) iMatching))
-        {
-          fprintf(stderr, "Unable to init association from pipe.\n");
-        }
-      }
-      else if (!oAssoc.initFromFile((CntUsage_e) iUsage,
-                                    (CntSelector_e) iSelector,
-                                    (CntMatching_e) iMatching,
-                                    sCertFile))
       {
+        failed = true;
+        fprintf(stderr, "Unable to init association from pipe.\n");
+      }
+      if (!failed && !pipeMode && oAssoc.initFromFile((CntUsage_e) iUsage,
+                                      (CntSelector_e) iSelector,
+                                      (CntMatching_e) iMatching,
+                                      sCertFile))
+      {
+        failed = true;
         fprintf(stderr, "Unable to init association.\n");
       }
-      else if (!oAssoc.toText(sTxt))
+      else if (!failed && !oAssoc.toText(sTxt))
       {
+        failed = true;
         fprintf(stderr, "Unable to get text of association.\n");
       }
-      else
+      if (!failed)
       {
         // fprintf(stdout, "%s IN TYPE%d %s;\n", oID.getSmimeName().c_str(), CNT_SMIMEA_RR_TYPE, sTxt.c_str());
         fprintf(stdout, "%s IN SMIMEA %s;\n", oID.getSmimeName().c_str(), sTxt.c_str());


### PR DESCRIPTION
Add functionality to pipe cert rather than point at filesystem. Would eliminate file system and caching complexity for high-concurrency usage (like for webserver scripts e.g. DANEportal).

**Tested and confirmed bug-free and fully maintains previous functionality.** Simply omit file name argument to handle piped file.
![Screenshot 2021-02-12 175007](https://user-images.githubusercontent.com/45672943/107830903-ca183380-6d5a-11eb-99c8-55eff05625bf.png)

